### PR TITLE
jupyterlab-variableinspector 3.2.4 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
 aggregate_check: false

--- a/recipe/0001-Bump-jupyter-web-components-to-0.16.patch
+++ b/recipe/0001-Bump-jupyter-web-components-to-0.16.patch
@@ -1,59 +1,13 @@
-From cd1a6db78f6fa84623bb17971a34ba007a42d3fe Mon Sep 17 00:00:00 2001
-From: Ian Thomas <ianthomas23@gmail.com>
-Date: Fri, 7 Feb 2025 09:34:00 +0000
-Subject: [PATCH] Bump @jupyter/web-components to 0.16
-
----
- package.json |  2 +-
- yarn.lock    | 10 +++++-----
- 2 files changed, 6 insertions(+), 6 deletions(-)
-
-diff --git a/package.json b/package.json
-index d7a4a4b..033b051 100644
---- a/package.json
-+++ b/package.json
+diff --git a/lckr_jupyterlab_variableinspector/labextension/package.json b/lckr_jupyterlab_variableinspector/labextension/package.json
+index 6921556..0cb4fd5 100644
+--- a/lckr_jupyterlab_variableinspector/labextension/package.json
++++ b/lckr_jupyterlab_variableinspector/labextension/package.json
 @@ -53,7 +53,7 @@
-     },
-     "packageManager": "yarn@3.5.0",
-     "dependencies": {
--        "@jupyter/web-components": "^0.15.0",
-+        "@jupyter/web-components": "^0.16.0",
-         "@jupyterlab/application": "^4.0.0",
-         "@jupyterlab/apputils": "^4.0.0",
-         "@jupyterlab/console": "^4.0.0",
-diff --git a/yarn.lock b/yarn.lock
-index cdae0de..02a11a9 100644
---- a/yarn.lock
-+++ b/yarn.lock
-@@ -485,15 +485,15 @@ __metadata:
-   languageName: node
-   linkType: hard
- 
--"@jupyter/web-components@npm:^0.15.0":
--  version: 0.15.3
--  resolution: "@jupyter/web-components@npm:0.15.3"
-+"@jupyter/web-components@npm:^0.16.0":
-+  version: 0.16.7
-+  resolution: "@jupyter/web-components@npm:0.16.7"
-   dependencies:
-     "@microsoft/fast-colors": ^5.3.1
-     "@microsoft/fast-element": ^1.12.0
-     "@microsoft/fast-foundation": ^2.49.4
-     "@microsoft/fast-web-utilities": ^5.4.1
--  checksum: a0980af934157bfdbdb6cc169c0816c1b2e57602d524c56bdcef746a4c25dfeb8f505150d83207c8695ed89b5486cf53d35a3382584d25ef64db666e4e16e45b
-+  checksum: ec3336247bbabb2e2587c2cf8b9d0e80786b454916dd600b3d6791bf08c3d1e45a7ec1becf366a5491ab56b0be020baa8c50a5b6067961faf5ec904de31243aa
-   languageName: node
-   linkType: hard
- 
-@@ -1124,7 +1124,7 @@ __metadata:
-   version: 0.0.0-use.local
-   resolution: "@lckr/jupyterlab_variableinspector@workspace:."
-   dependencies:
--    "@jupyter/web-components": ^0.15.0
-+    "@jupyter/web-components": ^0.16.0
-     "@jupyterlab/application": ^4.0.0
-     "@jupyterlab/apputils": ^4.0.0
-     "@jupyterlab/builder": ^4.0.0
--- 
-2.43.0
-
+   },
+   "packageManager": "yarn@3.5.0",
+   "dependencies": {
+-    "@jupyter/web-components": "^0.15.0",
++    "@jupyter/web-components": "^0.16.0",
+     "@jupyterlab/application": "^4.0.0",
+     "@jupyterlab/apputils": "^4.0.0",
+     "@jupyterlab/console": "^4.0.0",

--- a/recipe/0001-Bump-jupyter-web-components-to-0.16.patch
+++ b/recipe/0001-Bump-jupyter-web-components-to-0.16.patch
@@ -1,0 +1,59 @@
+From cd1a6db78f6fa84623bb17971a34ba007a42d3fe Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Fri, 7 Feb 2025 09:34:00 +0000
+Subject: [PATCH] Bump @jupyter/web-components to 0.16
+
+---
+ package.json |  2 +-
+ yarn.lock    | 10 +++++-----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/package.json b/package.json
+index d7a4a4b..033b051 100644
+--- a/package.json
++++ b/package.json
+@@ -53,7 +53,7 @@
+     },
+     "packageManager": "yarn@3.5.0",
+     "dependencies": {
+-        "@jupyter/web-components": "^0.15.0",
++        "@jupyter/web-components": "^0.16.0",
+         "@jupyterlab/application": "^4.0.0",
+         "@jupyterlab/apputils": "^4.0.0",
+         "@jupyterlab/console": "^4.0.0",
+diff --git a/yarn.lock b/yarn.lock
+index cdae0de..02a11a9 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -485,15 +485,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"@jupyter/web-components@npm:^0.15.0":
+-  version: 0.15.3
+-  resolution: "@jupyter/web-components@npm:0.15.3"
++"@jupyter/web-components@npm:^0.16.0":
++  version: 0.16.7
++  resolution: "@jupyter/web-components@npm:0.16.7"
+   dependencies:
+     "@microsoft/fast-colors": ^5.3.1
+     "@microsoft/fast-element": ^1.12.0
+     "@microsoft/fast-foundation": ^2.49.4
+     "@microsoft/fast-web-utilities": ^5.4.1
+-  checksum: a0980af934157bfdbdb6cc169c0816c1b2e57602d524c56bdcef746a4c25dfeb8f505150d83207c8695ed89b5486cf53d35a3382584d25ef64db666e4e16e45b
++  checksum: ec3336247bbabb2e2587c2cf8b9d0e80786b454916dd600b3d6791bf08c3d1e45a7ec1becf366a5491ab56b0be020baa8c50a5b6067961faf5ec904de31243aa
+   languageName: node
+   linkType: hard
+ 
+@@ -1124,7 +1124,7 @@ __metadata:
+   version: 0.0.0-use.local
+   resolution: "@lckr/jupyterlab_variableinspector@workspace:."
+   dependencies:
+-    "@jupyter/web-components": ^0.15.0
++    "@jupyter/web-components": ^0.16.0
+     "@jupyterlab/application": ^4.0.0
+     "@jupyterlab/apputils": ^4.0.0
+     "@jupyterlab/builder": ^4.0.0
+-- 
+2.43.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,9 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - hatch-jupyter-builder >=0.5
     - hatch-nodejs-version >=0.3.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lckr_jupyterlab_variableinspector" %}
-{% set version = "3.1.0" %}
+{% set version = "3.2.4" %}
 
 package:
   name: jupyterlab-variableinspector
@@ -7,10 +7,19 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0733fff6b78658cc4237076d105c9d19499a204deb1b800ffa65c23d236e722a
+  sha256: 9bad61401ef24cbdd4bc000d882038bbdd9d79550f624bd1930978dd56dddf7b
+  patches:
+    # Upstream specification:
+    # - jupyterlab >=4.0.0,<5
+    # But there's a conflict in package.json for jupyterlab >=4.3 and jupyterlab-variableinspector 3.2.4
+    # Conflicting Dependencies:
+    # JupyterLab              Extension        Package
+    # >=0.16.6 <0.17.0        >=0.15.0 <0.16.0 @jupyter/web-components
+    # There's a PR to solve it: https://github.com/jupyterlab-contrib/jupyterlab-variableInspector/pull/338
+    - 0001-Bump-jupyter-web-components-to-0.16.patch
 
 build:
-  skip: true # [py<38 or s390x]
+  skip: true # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -18,23 +27,25 @@ requirements:
   host:
     - hatch-jupyter-builder >=0.5
     - hatch-nodejs-version >=0.3.2
+    - jupyterlab ==4.3.4
     - hatchling >=1.5.0
     - pip
     - python
   run:
     - python
-    - jupyterlab >=3,<5
+    - jupyterlab >=4.0.0,<5
 
 test:
   imports:
     - lckr_jupyterlab_variableinspector
   requires:
-    - jupyterlab =4
+    - jupyterlab
     - pip
     - m2-grep # [win]
   commands:
     - pip check
-    - jupyter labextension list
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - jupyter labextension list --verbose
     - jupyter labextension list 2>&1 | grep -ie "@lckr/jupyterlab_variableinspector.*OK.*(python, lckr_jupyterlab_variableinspector)"
 
 about:
@@ -45,6 +56,7 @@ about:
   summary: Variable Inspector extension for Jupyterlab.
   dev_url: https://github.com/jupyterlab-contrib/jupyterlab-variableInspector
   doc_url: https://github.com/jupyterlab-contrib/jupyterlab-variableInspector
+  description: Jupyterlab extension that shows currently used variables and their values.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ about:
   license_file: LICENSE
   summary: Variable Inspector extension for Jupyterlab.
   dev_url: https://github.com/jupyterlab-contrib/jupyterlab-variableInspector
-  doc_url: https://github.com/jupyterlab-contrib/jupyterlab-variableInspector
+  doc_url: https://jupyterlab-contrib.github.io/jupyterlab-variableInspector.html
   description: Jupyterlab extension that shows currently used variables and their values.
 
 extra:


### PR DESCRIPTION
jupyterlab-variableinspector 3.2.4 

**Destination channel:** Defaults

### Links

- [PKG-7298]
- dev_url:        https://github.com/jupyterlab-contrib/jupyterlab-variableInspector/tree/v3.2.4
- conda_forge:    https://github.com/conda-forge/jupyterlab-variableinspector-feedstock
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- new version number


[PKG-7298]: https://anaconda.atlassian.net/browse/PKG-7298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ